### PR TITLE
Fixed compiler error.

### DIFF
--- a/starry_fmu/RTOS/components/finsh/finsh.h
+++ b/starry_fmu/RTOS/components/finsh/finsh.h
@@ -60,6 +60,10 @@
 #if defined(RT_USING_NEWLIB) || defined (RT_USING_MINILIBC)
 #include <sys/types.h>
 #include <string.h>
+#ifndef __u_char_defined
+typedef unsigned char u_char;
+#define __u_char_defined
+#endif
 #else
 typedef unsigned char  u_char;
 typedef unsigned short u_short;


### PR DESCRIPTION
Some versions of the GCC compiler, no u_char type was defined.